### PR TITLE
add settings model with option for overriding import/export config

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -42,6 +42,19 @@ class Plugin extends PluginBase
         ];
     }
 
+    public function registerSettings()
+    {
+        return [
+            'config' => [
+                'label' => 'User Import/Export',
+                'icon' => 'oc-icon-user',
+                'description' => '',
+                'class' => \VojtaSvoboda\UserImportExport\Models\Settings::class,
+                'order' => 600,
+            ],
+        ];
+    }
+
     public function boot()
     {
         Event::listen('backend.menu.extendItems', function($manager)

--- a/controllers/UserImportExport.php
+++ b/controllers/UserImportExport.php
@@ -2,6 +2,7 @@
 
 use BackendMenu;
 use Backend\Classes\Controller;
+use VojtaSvoboda\UserImportExport\Models\Settings as SettingsModel;
 
 class UserImportExport extends Controller
 {
@@ -13,6 +14,11 @@ class UserImportExport extends Controller
 
     public function __construct()
     {
+        $custom_config = SettingsModel::get('controller_config_override', null);
+        if($custom_config){
+            $this->importExportConfig = $custom_config;
+        }
+
         parent::__construct();
 
         BackendMenu::setContext('RainLab.User', 'user', $this->action);

--- a/models/Settings.php
+++ b/models/Settings.php
@@ -1,0 +1,12 @@
+<?php namespace VojtaSvoboda\UserImportExport\Models;
+
+use Model;
+
+class Settings extends Model
+{
+    public $implement = [
+        \System\Behaviors\SettingsModel::class
+    ];
+    public $settingsCode = 'vojtasvoboda_userimportexport_settings';
+    public $settingsFields = 'fields.yml';
+}

--- a/models/settings/fields.yml
+++ b/models/settings/fields.yml
@@ -1,0 +1,7 @@
+tabs:
+  fields:
+    controller_config_override:
+      label: Custom Config
+      span: full
+      type: text
+      commentAbove: "Replace the default Import/Export Config spec with your own."


### PR DESCRIPTION
Provide a backend config option to allow end-users to inject custom [$importExportConfig](https://octobercms.com/docs/backend/import-export#configuring-import-export). 

RainLab/User might be _the most_ extended plugin on the market. This config allows a (fairly advanced) feature for overriding the default import/export config. 

Example Usage: 
![Customized Export](https://user-images.githubusercontent.com/12756908/71019957-55e7ee80-20c9-11ea-8c02-b3345e7f0501.png)

- In my custom plugin, I add a folder at `$/my/plugin/vojtasvoboda_userimportexport/`
- add `config_import_export.yaml` 
```
import:
  title: Import Users
  modelClass: VojtaSvoboda\UserImportExport\Models\UserImportModel
  list: $/vojtasvoboda/userimportexport/models/userimport/columns.yaml # uses default config for import
  redirect: rainlab/user/users

export:
  title: Export Users
  modelClass: VojtaSvoboda\UserImportExport\Models\UserExportModel
  list: $/my/plugin/vojtasvoboda_userimportexport/userexport_columns.yaml # uses customized config for export
  redirect: rainlab/user/users
```
- add a custom `userexport_columns.yaml`
```
# ===================================
#  Column Definitions
# ===================================

columns:

  id:
    label: Id
    invisible: true

  username:
    label: rainlab.user::lang.user.username
    searchable: true
    invisible: true

  name:
    label: rainlab.user::lang.user.name
    searchable: true

  surname:
    label: rainlab.user::lang.user.surname
    searchable: true
    invisible: true

  email:
    label: rainlab.user::lang.user.email
    searchable: true

  // Custom fields added elsewhere
  address_1:
    label: Address
  address_2:
    label: Address 2
  city:
    label: City
  state_region:
    label: State
  postcode:
    label: Zip Code
  country:
    label: Country
  membership_payment_source:
    label: Source
  member_status:
    label: Status
```
- In October backend/admin navigate to `/system/settings/update/vojtasvoboda/userimportexport/config` and add `$/my/plugin/vojtasvoboda_userimportexport/config_import_export.yaml` as the custom override. 